### PR TITLE
feat: add update endpoints and editing UI

### DIFF
--- a/backend/routes/alerts.js
+++ b/backend/routes/alerts.js
@@ -14,6 +14,13 @@ router.post('/', async (req, res) => {
     res.json(alert);
 });
 
+router.put('/:id', async (req, res) => {
+    const alert = await Alert.findByIdAndUpdate(req.params.id, req.body, {
+        new: true,
+    });
+    res.json(alert);
+});
+
 router.delete('/:id', async (req, res) => {
     await Alert.findByIdAndDelete(req.params.id);
     res.json({ message: 'Alert deleted' });

--- a/backend/routes/assets.js
+++ b/backend/routes/assets.js
@@ -13,6 +13,13 @@ router.post('/', async (req, res) => {
   res.json(asset);
 });
 
+router.put('/:id', async (req, res) => {
+  const asset = await Asset.findByIdAndUpdate(req.params.id, req.body, {
+    new: true,
+  });
+  res.json(asset);
+});
+
 router.delete('/:id', async (req, res) => {
   await Asset.findByIdAndDelete(req.params.id);
   res.json({ message: 'Asset deleted' });

--- a/backend/routes/indicators.js
+++ b/backend/routes/indicators.js
@@ -14,6 +14,13 @@ router.post('/', async (req, res) => {
     res.json(indicator);
 });
 
+router.put('/:id', async (req, res) => {
+    const indicator = await Indicator.findByIdAndUpdate(req.params.id, req.body, {
+        new: true,
+    });
+    res.json(indicator);
+});
+
 router.delete('/:id', async (req, res) => {
     await Indicator.findByIdAndDelete(req.params.id);
     res.json({ message: 'Indicator deleted' });

--- a/backend/routes/trades.js
+++ b/backend/routes/trades.js
@@ -17,6 +17,13 @@ router.post('/', async (req, res) => {
   res.json(trade);
 });
 
+router.put('/:id', async (req, res) => {
+  const trade = await Trade.findByIdAndUpdate(req.params.id, req.body, {
+    new: true,
+  }).populate('asset');
+  res.json(trade);
+});
+
 router.delete('/:id', async (req, res) => {
   await Trade.findByIdAndDelete(req.params.id);
   res.json({ message: 'Trade deleted' });

--- a/frontend/src/components/Alerts.js
+++ b/frontend/src/components/Alerts.js
@@ -3,12 +3,17 @@ import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { List, ListItem, ListItemText, IconButton, TextField, Button } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
+import CancelIcon from '@mui/icons-material/Cancel';
 
 function Alerts() {
     const [alerts, setAlerts] = useState([]);
     const [asset, setAsset] = useState('');
     const [condition, setCondition] = useState('');
     const [targetPrice, setTargetPrice] = useState('');
+    const [editingId, setEditingId] = useState(null);
+    const [editingAlert, setEditingAlert] = useState({ asset: '', condition: '', targetPrice: '' });
 
     const fetchAlerts = useCallback(async () => {
         try {
@@ -44,6 +49,30 @@ function Alerts() {
         }
     };
 
+    const startEdit = (alert) => {
+        setEditingId(alert._id);
+        setEditingAlert({
+            asset: alert.asset,
+            condition: alert.condition,
+            targetPrice: alert.targetPrice,
+        });
+    };
+
+    const cancelEdit = () => {
+        setEditingId(null);
+        setEditingAlert({ asset: '', condition: '', targetPrice: '' });
+    };
+
+    const handleUpdateAlert = async () => {
+        try {
+            const response = await axios.put(`/api/alerts/${editingId}`, editingAlert);
+            setAlerts(alerts.map((alert) => (alert._id === editingId ? response.data : alert)));
+            cancelEdit();
+        } catch (error) {
+            console.error('Error updating alert:', error);
+        }
+    };
+
     return (
         <div>
             <h2>Alerts</h2>
@@ -76,12 +105,43 @@ function Alerts() {
             <List>
                 {alerts.map(alert => (
                     <ListItem key={alert._id}>
-                        <ListItemText
-                            primary={`${alert.asset} - ${alert.condition} - ${alert.targetPrice}`}
-                        />
-                        <IconButton edge="end" onClick={() => handleDeleteAlert(alert._id)}>
-                            <DeleteIcon />
-                        </IconButton>
+                        {editingId === alert._id ? (
+                            <>
+                                <TextField
+                                    value={editingAlert.asset}
+                                    onChange={e => setEditingAlert({ ...editingAlert, asset: e.target.value })}
+                                    margin="dense"
+                                />
+                                <TextField
+                                    value={editingAlert.condition}
+                                    onChange={e => setEditingAlert({ ...editingAlert, condition: e.target.value })}
+                                    margin="dense"
+                                />
+                                <TextField
+                                    value={editingAlert.targetPrice}
+                                    onChange={e => setEditingAlert({ ...editingAlert, targetPrice: e.target.value })}
+                                    margin="dense"
+                                />
+                                <IconButton edge="end" onClick={handleUpdateAlert}>
+                                    <SaveIcon />
+                                </IconButton>
+                                <IconButton edge="end" onClick={cancelEdit}>
+                                    <CancelIcon />
+                                </IconButton>
+                            </>
+                        ) : (
+                            <>
+                                <ListItemText
+                                    primary={`${alert.asset} - ${alert.condition} - ${alert.targetPrice}`}
+                                />
+                                <IconButton edge="end" onClick={() => startEdit(alert)}>
+                                    <EditIcon />
+                                </IconButton>
+                                <IconButton edge="end" onClick={() => handleDeleteAlert(alert._id)}>
+                                    <DeleteIcon />
+                                </IconButton>
+                            </>
+                        )}
                     </ListItem>
                 ))}
             </List>

--- a/frontend/src/components/AssetManager.js
+++ b/frontend/src/components/AssetManager.js
@@ -1,11 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { TextField, Button, List, ListItem, ListItemText, IconButton } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
+import CancelIcon from '@mui/icons-material/Cancel';
 import axios from 'axios';
 
 const AssetManager = () => {
   const [assets, setAssets] = useState([]);
   const [newAsset, setNewAsset] = useState('');
+  const [editingId, setEditingId] = useState(null);
+  const [editingName, setEditingName] = useState('');
 
   useEffect(() => {
     fetchAssets();
@@ -39,6 +44,26 @@ const AssetManager = () => {
     }
   };
 
+  const startEdit = (asset) => {
+    setEditingId(asset._id);
+    setEditingName(asset.name);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditingName('');
+  };
+
+  const updateAsset = async () => {
+    try {
+      const response = await axios.put(`/api/assets/${editingId}`, { name: editingName });
+      setAssets(assets.map((asset) => (asset._id === editingId ? response.data : asset)));
+      cancelEdit();
+    } catch (error) {
+      console.error('Error updating asset:', error);
+    }
+  };
+
   return (
     <div>
       <h2>Asset Manager</h2>
@@ -51,10 +76,30 @@ const AssetManager = () => {
       <List>
         {assets.map((asset) => (
           <ListItem key={asset._id}>
-            <ListItemText primary={asset.name} />
-            <IconButton edge="end" onClick={() => deleteAsset(asset._id)}>
-              <DeleteIcon />
-            </IconButton>
+            {editingId === asset._id ? (
+              <>
+                <TextField
+                  value={editingName}
+                  onChange={(e) => setEditingName(e.target.value)}
+                />
+                <IconButton edge="end" onClick={updateAsset}>
+                  <SaveIcon />
+                </IconButton>
+                <IconButton edge="end" onClick={cancelEdit}>
+                  <CancelIcon />
+                </IconButton>
+              </>
+            ) : (
+              <>
+                <ListItemText primary={asset.name} />
+                <IconButton edge="end" onClick={() => startEdit(asset)}>
+                  <EditIcon />
+                </IconButton>
+                <IconButton edge="end" onClick={() => deleteAsset(asset._id)}>
+                  <DeleteIcon />
+                </IconButton>
+              </>
+            )}
           </ListItem>
         ))}
       </List>

--- a/frontend/src/components/Indicators.js
+++ b/frontend/src/components/Indicators.js
@@ -3,11 +3,16 @@ import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { List, ListItem, ListItemText, IconButton, TextField, Button } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import SaveIcon from '@mui/icons-material/Save';
+import CancelIcon from '@mui/icons-material/Cancel';
 
 function Indicators() {
     const [indicators, setIndicators] = useState([]);
     const [name, setName] = useState('');
     const [description, setDescription] = useState('');
+    const [editingId, setEditingId] = useState(null);
+    const [editingIndicator, setEditingIndicator] = useState({ name: '', description: '' });
 
     const fetchIndicators = useCallback(async () => {
         try {
@@ -42,6 +47,26 @@ function Indicators() {
         }
     };
 
+    const startEdit = (indicator) => {
+        setEditingId(indicator._id);
+        setEditingIndicator({ name: indicator.name, description: indicator.description });
+    };
+
+    const cancelEdit = () => {
+        setEditingId(null);
+        setEditingIndicator({ name: '', description: '' });
+    };
+
+    const handleUpdateIndicator = async () => {
+        try {
+            const response = await axios.put(`/api/indicators/${editingId}`, editingIndicator);
+            setIndicators(indicators.map((indicator) => (indicator._id === editingId ? response.data : indicator)));
+            cancelEdit();
+        } catch (error) {
+            console.error('Error updating indicator:', error);
+        }
+    };
+
     return (
         <div>
             <h2>Indicators</h2>
@@ -67,13 +92,39 @@ function Indicators() {
             <List>
                 {indicators.map(indicator => (
                     <ListItem key={indicator._id}>
-                        <ListItemText
-                            primary={indicator.name}
-                            secondary={indicator.description}
-                        />
-                        <IconButton edge="end" onClick={() => handleDeleteIndicator(indicator._id)}>
-                            <DeleteIcon />
-                        </IconButton>
+                        {editingId === indicator._id ? (
+                            <>
+                                <TextField
+                                    value={editingIndicator.name}
+                                    onChange={e => setEditingIndicator({ ...editingIndicator, name: e.target.value })}
+                                    margin="dense"
+                                />
+                                <TextField
+                                    value={editingIndicator.description}
+                                    onChange={e => setEditingIndicator({ ...editingIndicator, description: e.target.value })}
+                                    margin="dense"
+                                />
+                                <IconButton edge="end" onClick={handleUpdateIndicator}>
+                                    <SaveIcon />
+                                </IconButton>
+                                <IconButton edge="end" onClick={cancelEdit}>
+                                    <CancelIcon />
+                                </IconButton>
+                            </>
+                        ) : (
+                            <>
+                                <ListItemText
+                                    primary={indicator.name}
+                                    secondary={indicator.description}
+                                />
+                                <IconButton edge="end" onClick={() => startEdit(indicator)}>
+                                    <EditIcon />
+                                </IconButton>
+                                <IconButton edge="end" onClick={() => handleDeleteIndicator(indicator._id)}>
+                                    <DeleteIcon />
+                                </IconButton>
+                            </>
+                        )}
                     </ListItem>
                 ))}
             </List>

--- a/frontend/src/components/TradeList.js
+++ b/frontend/src/components/TradeList.js
@@ -6,6 +6,8 @@ const TradeList = () => {
   const [trades, setTrades] = useState([]);
   const [newTrade, setNewTrade] = useState({ asset: '', price: '', quantity: '' });
   const [assets, setAssets] = useState([]);
+  const [editingId, setEditingId] = useState(null);
+  const [editingTrade, setEditingTrade] = useState({ asset: '', price: '', quantity: '' });
 
   useEffect(() => {
     fetchTrades();
@@ -49,6 +51,30 @@ const TradeList = () => {
     }
   };
 
+  const startEdit = (trade) => {
+    setEditingId(trade._id);
+    setEditingTrade({
+      asset: trade.asset._id,
+      price: trade.price,
+      quantity: trade.quantity,
+    });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditingTrade({ asset: '', price: '', quantity: '' });
+  };
+
+  const updateTrade = async () => {
+    try {
+      const response = await axios.put(`/api/trades/${editingId}`, editingTrade);
+      setTrades(trades.map((trade) => (trade._id === editingId ? response.data : trade)));
+      cancelEdit();
+    } catch (error) {
+      console.error('Error updating trade:', error);
+    }
+  };
+
   return (
     <div>
       <h2>Trade List</h2>
@@ -78,8 +104,37 @@ const TradeList = () => {
       <ul>
         {trades.map((trade) => (
           <li key={trade._id}>
-            {trade.asset.name} - {trade.price} - {trade.quantity}
-            <Button onClick={() => deleteTrade(trade._id)}>Delete</Button>
+            {editingId === trade._id ? (
+              <>
+                <TextField
+                  select
+                  value={editingTrade.asset}
+                  onChange={(e) => setEditingTrade({ ...editingTrade, asset: e.target.value })}
+                >
+                  {assets.map((asset) => (
+                    <MenuItem key={asset._id} value={asset._id}>
+                      {asset.name}
+                    </MenuItem>
+                  ))}
+                </TextField>
+                <TextField
+                  value={editingTrade.price}
+                  onChange={(e) => setEditingTrade({ ...editingTrade, price: e.target.value })}
+                />
+                <TextField
+                  value={editingTrade.quantity}
+                  onChange={(e) => setEditingTrade({ ...editingTrade, quantity: e.target.value })}
+                />
+                <Button onClick={updateTrade}>Save</Button>
+                <Button onClick={cancelEdit}>Cancel</Button>
+              </>
+            ) : (
+              <>
+                {trade.asset.name} - {trade.price} - {trade.quantity}
+                <Button onClick={() => startEdit(trade)}>Edit</Button>
+                <Button onClick={() => deleteTrade(trade._id)}>Delete</Button>
+              </>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- allow updating assets, trades, alerts and indicators via new PUT routes
- enable inline editing in asset, trade, alert and indicator components to call update APIs and refresh state

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `CI=true npm test` (frontend) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a570c66c60832b9fbe4785c1c7d992